### PR TITLE
gitmodules: don't use deprecated git protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/hiredis"]
 	path = vendor/hiredis
-	url = git://github.com/redis/hiredis.git
+	url = https://github.com/redis/hiredis.git


### PR DESCRIPTION
Github has deprecated this so it breaks some builds -
https://github.blog/2021-09-01-improving-git-protocol-security-github/.